### PR TITLE
Move hide logic to datasource.ts filter and reuse client for test connection

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -45,4 +45,8 @@ export class DataSource extends DataSourceWithBackend<Query, CloudLoggingOptions
       return [];
     }
   }
+
+  filterQuery(query: Query): boolean {
+    return !query.hide;
+  }
 }


### PR DESCRIPTION
Hide logic is moved out of backend code and instead moved to filter method on datasource.ts
Backend datasource client is reused for CheckHealth method