### PR TITLE
feat(grafana-compatibility): Use query field from query params too.

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -49,6 +49,12 @@ export function LoggingQueryEditor({ datasource, query, range, onChange, onRunQu
   if (!query.projectId) {
     datasource.getDefaultProject().then(r => query.projectId = r);
   }
+
+  // Check query field from query params to support default way of propagating query from other parts of grafana.
+  if (query.query !== null) {
+    query.queryText = query.query;
+  }
+
   if (query.queryText == null) {
     query.queryText = defaultQuery.queryText;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface DataSourceOptionsExt extends DataSourceOptions {
  */
 export interface Query extends DataQuery {
   queryText?: string;
+  query?: string;
   projectId: string;
 }
 


### PR DESCRIPTION
Hello, I am currently working on adding "Trace to Logs" support to this plugin in Grafana. During implementation, I discovered that Grafana sends the generated query through the "query" field in the query parameters. However, this plugin expects to receive the GQL query from the "queryText" field in the query parameters. Therefore, I have found a simple solution to add support for the "query" field.