### PR TITLE
Output in Marshaled JSON when LogEntry has JSON payload

### DIFF
--- a/pkg/plugin/cloudlogging/cloudlogging.go
+++ b/pkg/plugin/cloudlogging/cloudlogging.go
@@ -36,7 +36,11 @@ func GetLogEntryMessage(entry *loggingpb.LogEntry) (string, error) {
 		if msg, ok := t.JsonPayload.Fields["message"]; ok {
 			return msg.GetStringValue(), nil
 		}
-		return t.JsonPayload.String(), nil
+		byteArr, err := t.JsonPayload.MarshalJSON()
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal JSON payload: %v", err)
+		}
+		return string(byteArr), nil
 	case *loggingpb.LogEntry_TextPayload:
 		return t.TextPayload, nil
 	case *loggingpb.LogEntry_ProtoPayload:

--- a/pkg/plugin/cloudlogging/cloudlogging_test.go
+++ b/pkg/plugin/cloudlogging/cloudlogging_test.go
@@ -94,18 +94,7 @@ func TestGetLogEntryMessage(t *testing.T) {
 				},
 			},
 			expected: &expectedResult{
-				message: loggingpb.LogEntry_JsonPayload{
-					JsonPayload: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"severity": {
-								Kind: &structpb.Value_StringValue{StringValue: "INFO"},
-							},
-							"database_role": {
-								Kind: &structpb.Value_StringValue{StringValue: "user"},
-							},
-						},
-					},
-				}.JsonPayload.String(),
+				message: "{\"database_role\":\"user\",\"severity\":\"INFO\"}",
 			},
 		},
 		{


### PR DESCRIPTION
When the `LogEntry`'s payload is a JOSN one, the plugin currently output the text proto representation of the `Struct` proto. 

For a JSON payload of 
```
{"database_role":"user", "severity":"INFO"}
```
, the output shown in the panel will be 
```
"fields:{key:"database_role\"  value:{string_value:"user"}}  fields:{key:"severity"  value:{string_value:"INFO"}}"
```

This is not very readable for human. This PR output the payload in JSON directly.

TEST=verified on local Grafana